### PR TITLE
Replace 'other' feature class with 'positive'/'negative'

### DIFF
--- a/library/src/main/java/org/isaacphysics/graphchecker/features/SlopeFeature.java
+++ b/library/src/main/java/org/isaacphysics/graphchecker/features/SlopeFeature.java
@@ -98,10 +98,11 @@ public class SlopeFeature extends LineFeature<SlopeFeature.Instance, SlopeFeatur
      * The shape of the slope.
      */
     enum Slope implements HumanNamedEnum {
-        FLAT, // Nearly horizontal
         UP, // Nearly vertical going upwards
+        POSITIVE, // Between UP and FLAT
+        FLAT, // Nearly horizontal
+        NEGATIVE, // Between FLAT and DOWN
         DOWN, // Nearly vertical going downwards
-        OTHER // Any other slope
     }
 
     @Override
@@ -158,7 +159,6 @@ public class SlopeFeature extends LineFeature<SlopeFeature.Instance, SlopeFeatur
     public List<String> generate(Line expectedLine) {
         return Collections.singletonList(Arrays.stream(Position.values())
         .map(position -> ImmutablePair.of(position, lineToSlope(lineAtPosition(expectedLine, position))))
-        .filter(pair -> pair.getRight() != Slope.OTHER)
         .map(pair -> pair.getLeft().humanName() + "=" + pair.getRight().humanName())
         .collect(Collectors.joining(", ")));
     }
@@ -181,15 +181,19 @@ public class SlopeFeature extends LineFeature<SlopeFeature.Instance, SlopeFeatur
         }
 
         double highIfSteep = size.getY() / size.getX();
-        if (Math.abs(highIfSteep) > settings().getSlopeThreshold()) {
-            if (highIfSteep > 0) {
+        if (highIfSteep > 0) {
+            if (Math.abs(highIfSteep) > settings().getSlopeThreshold()) {
                 return Slope.UP;
             } else {
+                return Slope.POSITIVE;
+            }
+        } else {
+            if (Math.abs(highIfSteep) > settings().getSlopeThreshold()) {
                 return Slope.DOWN;
+            } else {
+                return Slope.NEGATIVE;
             }
         }
-
-        return Slope.OTHER;
     }
 
     /**

--- a/library/src/test/java/org/isaacphysics/graphchecker/features/SlopeFeatureTest.java
+++ b/library/src/test/java/org/isaacphysics/graphchecker/features/SlopeFeatureTest.java
@@ -35,13 +35,14 @@ public class SlopeFeatureTest {
 
     @Test
     public void slopeCalculatorIsCorrect() {
-        Map<Line, SlopeFeature.Slope> expectations = ImmutableMap.of(
-            TestHelpers.lineOf(new Point(0, 0), new Point(10, 100)), SlopeFeature.Slope.UP,
-            TestHelpers.lineOf(new Point(10, 0), new Point(15, -50)), SlopeFeature.Slope.DOWN,
-            TestHelpers.lineOf(new Point(0, 0), new Point(100, -5)), SlopeFeature.Slope.FLAT,
-            TestHelpers.lineOf(new Point(0, 0), new Point(-100, -5)), SlopeFeature.Slope.FLAT,
-            TestHelpers.lineOf(new Point(0, 0), new Point(100, 100)), SlopeFeature.Slope.OTHER
-        );
+        Map<Line, SlopeFeature.Slope> expectations = ImmutableMap.<Line, SlopeFeature.Slope>builder()
+                .put(TestHelpers.lineOf(new Point(0, 0), new Point(10, 100)), SlopeFeature.Slope.UP)
+                .put(TestHelpers.lineOf(new Point(10, 0), new Point(15, -50)), SlopeFeature.Slope.DOWN)
+                .put(TestHelpers.lineOf(new Point(0, 0), new Point(100, -5)), SlopeFeature.Slope.FLAT)
+                .put(TestHelpers.lineOf(new Point(0, 0), new Point(-100, -5)), SlopeFeature.Slope.FLAT)
+                .put(TestHelpers.lineOf(new Point(0, 0), new Point(100, 100)), SlopeFeature.Slope.POSITIVE)
+                .put(TestHelpers.lineOf(new Point(0, 0), new Point(100, -100)), SlopeFeature.Slope.NEGATIVE)
+                .build();
 
         expectations.forEach((line, slope) -> assertEquals(slope, slopeFeature.lineToSlope(line)));
     }


### PR DESCRIPTION
Instead of classifying all gradients between `flat` and `up`/`down` as `other`, they are classified as either `positive` or `negative`.