### PR TITLE
Add 'any' sector for POI matching, and new unordered match feature

### DIFF
--- a/library/src/main/java/org/isaacphysics/graphchecker/features/Features.java
+++ b/library/src/main/java/org/isaacphysics/graphchecker/features/Features.java
@@ -61,7 +61,8 @@ public class Features {
             new ExpectedSectorsFeature(settings),
             new SlopeFeature(settings),
             new SymmetryFeature(settings),
-            new PointsFeature(settings)
+            new PointsFeature(settings),
+            new UnorderedPointsFeature(settings)
         );
         curvesCountFeature = new CurvesCountFeature(settings);
         inputFeatures = ImmutableList.of(

--- a/library/src/main/java/org/isaacphysics/graphchecker/features/PointsFeature.java
+++ b/library/src/main/java/org/isaacphysics/graphchecker/features/PointsFeature.java
@@ -16,6 +16,7 @@
 package org.isaacphysics.graphchecker.features;
 
 import com.google.common.collect.Streams;
+import org.isaacphysics.graphchecker.data.PointOfInterest;
 import org.isaacphysics.graphchecker.features.internals.LineFeature;
 import org.isaacphysics.graphchecker.geometry.Sector;
 import org.isaacphysics.graphchecker.geometry.SectorBuilder;
@@ -53,7 +54,7 @@ public class PointsFeature extends LineFeature<PointsFeature.Instance, SectorCla
      */
     protected class Instance extends LineFeature<?, ?>.Instance {
 
-        private final List<ImmutablePair<PointType, Sector>> expectedPoints;
+        protected final List<ImmutablePair<PointType, Sector>> expectedPoints;
 
         /**
          * Create an instance which expects these points in order.
@@ -71,27 +72,31 @@ public class PointsFeature extends LineFeature<PointsFeature.Instance, SectorCla
                 return false;
             }
 
-            return Streams.zip(expectedPoints.stream(), line.getPointsOfInterest().stream(),
-                (expected, actual) -> expected.getLeft() == actual.getPointType()
-                    && settings().getSectorClassifier().classifyAll(actual).contains(expected.getRight()))
-                .allMatch(Boolean::booleanValue);
+            return Streams.zip(expectedPoints.stream(), line.getPointsOfInterest().stream(), this::pointsMatch)
+                    .allMatch(Boolean::booleanValue);
+        }
+        
+        protected boolean pointsMatch(ImmutablePair<PointType, Sector> expected, PointOfInterest actual) {
+            return expected.getLeft() == actual.getPointType() 
+                    && expected.getRight() == settings().getSectorBuilder().byName(SectorBuilder.ANY) 
+                        || (settings().getSectorClassifier().classifyAll(actual).contains(expected.getRight()));
         }
     }
 
     @Override
     public Instance deserializeInternal(String featureData) {
         String[] items = featureData.split("\\s*,\\s*");
-        return new Instance(featureData, Arrays.stream(items)
-            .map(item -> {
-                String[] parts = item.split(" (in|on|at) ");
-                if (parts.length != 2) {
-                    throw new IllegalArgumentException("Incorrect number of point parts in: " + item);
-                }
-                PointType expectedType = PointType.valueOf(parts[0].trim().toUpperCase());
-                Sector expectedSector = settings().getSectorBuilder().byName(parts[1].trim());
-                return ImmutablePair.of(expectedType, expectedSector);
-            })
-            .collect(Collectors.toList()));
+        return new Instance(featureData, Arrays.stream(items).map(this::deserializeItem).collect(Collectors.toList()));
+    }
+
+    protected ImmutablePair<PointType, Sector> deserializeItem(String item) {
+        String[] parts = item.split(" (in|on|at) ");
+        if (parts.length != 2) {
+            throw new IllegalArgumentException("Incorrect number of point parts in: " + item);
+        }
+        PointType expectedType = PointType.valueOf(parts[0].trim().toUpperCase());
+        Sector expectedSector = settings().getSectorBuilder().byName(parts[1].trim());
+        return ImmutablePair.of(expectedType, expectedSector);
     }
 
     @Override

--- a/library/src/main/java/org/isaacphysics/graphchecker/features/PointsFeature.java
+++ b/library/src/main/java/org/isaacphysics/graphchecker/features/PointsFeature.java
@@ -77,9 +77,9 @@ public class PointsFeature extends LineFeature<PointsFeature.Instance, SectorCla
         }
         
         protected boolean pointsMatch(ImmutablePair<PointType, Sector> expected, PointOfInterest actual) {
-            return expected.getLeft() == actual.getPointType() 
-                    && expected.getRight() == settings().getSectorBuilder().byName(SectorBuilder.ANY) 
-                        || (settings().getSectorClassifier().classifyAll(actual).contains(expected.getRight()));
+            return expected.getLeft() == actual.getPointType()
+                    && (expected.getRight() == settings().getSectorBuilder().byName(SectorBuilder.ANY)
+                    || settings().getSectorClassifier().classifyAll(actual).contains(expected.getRight()));
         }
     }
 

--- a/library/src/main/java/org/isaacphysics/graphchecker/features/UnorderedPointsFeature.java
+++ b/library/src/main/java/org/isaacphysics/graphchecker/features/UnorderedPointsFeature.java
@@ -52,9 +52,8 @@ public class UnorderedPointsFeature extends PointsFeature{
     }
 
     @Override
-    public PointsFeature.Instance deserializeInternal(String featureData) {
+    public Instance deserializeInternal(String featureData) {
         String[] items = featureData.split("\\s*,\\s*");
         return new Instance(featureData, Arrays.stream(items).map(this::deserializeItem).collect(Collectors.toSet()));
     }
-
 }

--- a/library/src/main/java/org/isaacphysics/graphchecker/features/UnorderedPointsFeature.java
+++ b/library/src/main/java/org/isaacphysics/graphchecker/features/UnorderedPointsFeature.java
@@ -1,0 +1,60 @@
+package org.isaacphysics.graphchecker.features;
+
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.checkerframework.checker.units.qual.A;
+import org.isaacphysics.graphchecker.data.Line;
+import org.isaacphysics.graphchecker.data.PointType;
+import org.isaacphysics.graphchecker.geometry.Sector;
+import org.isaacphysics.graphchecker.geometry.SectorClassifier;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class UnorderedPointsFeature extends PointsFeature{
+
+    /**
+     * Create a points feature with specified settings.
+     * @param settings The settings.
+     */
+    UnorderedPointsFeature(SectorClassifier.Settings settings) {
+        super(settings);
+    }
+
+    @Override
+    public String tag() {
+        return "has-points";
+    }
+
+    protected class Instance extends PointsFeature.Instance {
+
+        /**
+         * Create an instance which expects these to appear somewhere in the line, regardless of order.
+         *
+         * @param featureData    The specification for this feature.
+         * @param expectedPoints The points of interest.
+         */
+        Instance(String featureData, Set<ImmutablePair<PointType, Sector>> expectedPoints) {
+            super(featureData, new ArrayList<>(expectedPoints));
+        }
+
+        @Override
+        public boolean test(Line line){
+            for (ImmutablePair<PointType, Sector> expected : expectedPoints) {
+                if (line.getPointsOfInterest().stream().noneMatch(actual -> pointsMatch(expected, actual))){
+                    return false;
+                }
+            }
+            return true;
+        }
+    }
+
+    @Override
+    public PointsFeature.Instance deserializeInternal(String featureData) {
+        String[] items = featureData.split("\\s*,\\s*");
+        return new Instance(featureData, Arrays.stream(items).map(this::deserializeItem).collect(Collectors.toSet()));
+    }
+
+}

--- a/library/src/main/java/org/isaacphysics/graphchecker/features/UnorderedPointsFeature.java
+++ b/library/src/main/java/org/isaacphysics/graphchecker/features/UnorderedPointsFeature.java
@@ -1,7 +1,22 @@
+/**
+ * Copyright 2019 University of Cambridge
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.isaacphysics.graphchecker.features;
 
 import org.apache.commons.lang3.tuple.ImmutablePair;
-import org.checkerframework.checker.units.qual.A;
 import org.isaacphysics.graphchecker.data.Line;
 import org.isaacphysics.graphchecker.data.PointType;
 import org.isaacphysics.graphchecker.geometry.Sector;
@@ -9,7 +24,6 @@ import org.isaacphysics.graphchecker.geometry.SectorClassifier;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 

--- a/library/src/test/java/org/isaacphysics/graphchecker/features/PointsFeatureTest.java
+++ b/library/src/test/java/org/isaacphysics/graphchecker/features/PointsFeatureTest.java
@@ -21,6 +21,7 @@ import org.junit.Test;
 import org.isaacphysics.graphchecker.data.Line;
 
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertFalse;
@@ -50,6 +51,68 @@ public class PointsFeatureTest {
         pointsFeature.deserializeInternal("middle, flat");
     }
 
+    @Test
+    public void pointsFeature_curveWithPOIsMatchingSpec_matches(){
+        // Arrange
+        Line sine = TestHelpers.lineOf(Math::sin, -Math.PI, Math.PI);
+        String spec = "minima in bottomLeft, maxima in topRight";
 
+        // Act
+        boolean matches = pointsFeature.deserializeInternal(spec).test(sine);
 
+        // Assert
+        assertTrue(matches);
+    }
+
+    @Test
+    public void pointsFeature_curveWithPOIsMatchingAnySectorSpec_matches(){
+        // Arrange
+        Line sine = TestHelpers.lineOf(Math::sin, -Math.PI, Math.PI);
+        String spec = "minima in any, maxima in any";
+
+        // Act
+        boolean matches = pointsFeature.deserializeInternal(spec).test(sine);
+
+        // Assert
+        assertTrue(matches);
+    }
+
+    @Test
+    public void pointsFeature_curveWithPOIsMatchingPartialAnySectorSpec_matches(){
+        // Arrange
+        Line sine = TestHelpers.lineOf(Math::sin, -Math.PI, Math.PI);
+        String spec = "minima in any, maxima in topRight";
+
+        // Act
+        boolean matches = pointsFeature.deserializeInternal(spec).test(sine);
+
+        // Assert
+        assertTrue(matches);
+    }
+
+    @Test
+    public void pointsFeature_curveWithOutOfOrderPOIs_fails(){
+        // Arrange
+        Line sine = TestHelpers.lineOf(Math::sin, -Math.PI, Math.PI);
+        String spec = "maxima in topRight, minima in bottomLeft";
+
+        // Act
+        boolean matches = pointsFeature.deserializeInternal(spec).test(sine);
+
+        // Assert
+        assertFalse(matches);
+    }
+
+    @Test
+    public void pointsFeature_curveWithOutOfOrderPOIsAnySectorSpec_fails(){
+        // Arrange
+        Line sine = TestHelpers.lineOf(Math::sin, -Math.PI, Math.PI);
+        String spec = "maxima in any, minima in any";
+
+        // Act
+        boolean matches = pointsFeature.deserializeInternal(spec).test(sine);
+
+        // Assert
+        assertFalse(matches);
+    }
 }

--- a/library/src/test/java/org/isaacphysics/graphchecker/features/PointsFeatureTest.java
+++ b/library/src/test/java/org/isaacphysics/graphchecker/features/PointsFeatureTest.java
@@ -115,4 +115,17 @@ public class PointsFeatureTest {
         // Assert
         assertFalse(matches);
     }
+
+    @Test
+    public void pointsFeature_curveWithPOIsNotMatchingSpec_fails(){
+        // Arrange
+        Line sine = TestHelpers.lineOf(Math::sin, -Math.PI, Math.PI);
+        String spec = "maxima in topLeft, minima in topRight";
+
+        // Act
+        boolean matches = pointsFeature.deserializeInternal(spec).test(sine);
+
+        // Assert
+        assertFalse(matches);
+    }
 }

--- a/library/src/test/java/org/isaacphysics/graphchecker/features/PointsFeatureTest.java
+++ b/library/src/test/java/org/isaacphysics/graphchecker/features/PointsFeatureTest.java
@@ -21,7 +21,6 @@ import org.junit.Test;
 import org.isaacphysics.graphchecker.data.Line;
 
 import java.util.List;
-import java.util.Map;
 
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertFalse;

--- a/library/src/test/java/org/isaacphysics/graphchecker/features/UnorderedPointsFeatureTest.java
+++ b/library/src/test/java/org/isaacphysics/graphchecker/features/UnorderedPointsFeatureTest.java
@@ -1,0 +1,81 @@
+package org.isaacphysics.graphchecker.features;
+
+import org.isaacphysics.graphchecker.TestHelpers;
+import org.isaacphysics.graphchecker.data.Line;
+import org.isaacphysics.graphchecker.settings.SettingsWrapper;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class UnorderedPointsFeatureTest {
+
+    private final UnorderedPointsFeature unorderedPointsFeature = new UnorderedPointsFeature(SettingsWrapper.DEFAULT);
+
+    @Test
+    public void pointsFeature_curveWithPOIsMatchingSpec_matches(){
+        // Arrange
+        Line sine = TestHelpers.lineOf(Math::sin, -Math.PI, Math.PI);
+        String spec = "minima in bottomLeft, maxima in topRight";
+
+        // Act
+        boolean matches = unorderedPointsFeature.deserializeInternal(spec).test(sine);
+
+        // Assert
+        assertTrue(matches);
+    }
+
+    @Test
+    public void pointsFeature_curveWithPOIsMatchingAnySectorSpec_matches(){
+        // Arrange
+        Line sine = TestHelpers.lineOf(Math::sin, -Math.PI, Math.PI);
+        String spec = "minima in any, maxima in any";
+
+        // Act
+        boolean matches = unorderedPointsFeature.deserializeInternal(spec).test(sine);
+
+        // Assert
+        assertTrue(matches);
+    }
+
+    @Test
+    public void pointsFeature_curveWithPOIsMatchingPartialAnySectorSpec_matches(){
+        // Arrange
+        Line sine = TestHelpers.lineOf(Math::sin, -Math.PI, Math.PI);
+        String spec = "minima in any, maxima in topRight";
+
+        // Act
+        boolean matches = unorderedPointsFeature.deserializeInternal(spec).test(sine);
+
+        // Assert
+        assertTrue(matches);
+    }
+
+    @Test
+    public void pointsFeature_curveWithOutOfOrderPOIs_matches(){
+        // Arrange
+        Line sine = TestHelpers.lineOf(Math::sin, -Math.PI, Math.PI);
+        String spec = "maxima in topRight, minima in bottomLeft";
+
+        // Act
+        boolean matches = unorderedPointsFeature.deserializeInternal(spec).test(sine);
+
+        // Assert
+        assertTrue(matches);
+    }
+
+    @Test
+    public void pointsFeature_curveWithOutOfOrderPOIsAnySectorSpec_matches(){
+        // Arrange
+        Line sine = TestHelpers.lineOf(Math::sin, -Math.PI, Math.PI);
+        String spec = "maxima in any, minima in any";
+
+        // Act
+        boolean matches = unorderedPointsFeature.deserializeInternal(spec).test(sine);
+
+        // Assert
+        assertTrue(matches);
+    }
+}

--- a/library/src/test/java/org/isaacphysics/graphchecker/features/UnorderedPointsFeatureTest.java
+++ b/library/src/test/java/org/isaacphysics/graphchecker/features/UnorderedPointsFeatureTest.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 University of Cambridge
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.isaacphysics.graphchecker.features;
 
 import org.isaacphysics.graphchecker.TestHelpers;

--- a/library/src/test/java/org/isaacphysics/graphchecker/features/UnorderedPointsFeatureTest.java
+++ b/library/src/test/java/org/isaacphysics/graphchecker/features/UnorderedPointsFeatureTest.java
@@ -5,17 +5,15 @@ import org.isaacphysics.graphchecker.data.Line;
 import org.isaacphysics.graphchecker.settings.SettingsWrapper;
 import org.junit.Test;
 
-import java.util.List;
-
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 
 public class UnorderedPointsFeatureTest {
 
     private final UnorderedPointsFeature unorderedPointsFeature = new UnorderedPointsFeature(SettingsWrapper.DEFAULT);
 
     @Test
-    public void pointsFeature_curveWithPOIsMatchingSpec_matches(){
+    public void unorderedPointsFeature_curveWithPOIsMatchingSpec_matches(){
         // Arrange
         Line sine = TestHelpers.lineOf(Math::sin, -Math.PI, Math.PI);
         String spec = "minima in bottomLeft, maxima in topRight";
@@ -28,7 +26,7 @@ public class UnorderedPointsFeatureTest {
     }
 
     @Test
-    public void pointsFeature_curveWithPOIsMatchingAnySectorSpec_matches(){
+    public void unorderedPointsFeature_curveWithPOIsMatchingAnySectorSpec_matches(){
         // Arrange
         Line sine = TestHelpers.lineOf(Math::sin, -Math.PI, Math.PI);
         String spec = "minima in any, maxima in any";
@@ -41,7 +39,7 @@ public class UnorderedPointsFeatureTest {
     }
 
     @Test
-    public void pointsFeature_curveWithPOIsMatchingPartialAnySectorSpec_matches(){
+    public void unorderedPointsFeature_curveWithPOIsMatchingPartialAnySectorSpec_matches(){
         // Arrange
         Line sine = TestHelpers.lineOf(Math::sin, -Math.PI, Math.PI);
         String spec = "minima in any, maxima in topRight";
@@ -54,7 +52,7 @@ public class UnorderedPointsFeatureTest {
     }
 
     @Test
-    public void pointsFeature_curveWithOutOfOrderPOIs_matches(){
+    public void unorderedPointsFeature_curveWithOutOfOrderPOIs_matches(){
         // Arrange
         Line sine = TestHelpers.lineOf(Math::sin, -Math.PI, Math.PI);
         String spec = "maxima in topRight, minima in bottomLeft";
@@ -67,7 +65,7 @@ public class UnorderedPointsFeatureTest {
     }
 
     @Test
-    public void pointsFeature_curveWithOutOfOrderPOIsAnySectorSpec_matches(){
+    public void unorderedPointsFeature_curveWithOutOfOrderPOIsAnySectorSpec_matches(){
         // Arrange
         Line sine = TestHelpers.lineOf(Math::sin, -Math.PI, Math.PI);
         String spec = "maxima in any, minima in any";
@@ -77,5 +75,18 @@ public class UnorderedPointsFeatureTest {
 
         // Assert
         assertTrue(matches);
+    }
+
+    @Test
+    public void unorderedPointsFeature_curveWithPOIsNotMatchingSpec_fails(){
+        // Arrange
+        Line sine = TestHelpers.lineOf(Math::sin, -Math.PI, Math.PI);
+        String spec = "maxima in topLeft, minima in any";
+
+        // Act
+        boolean matches = unorderedPointsFeature.deserializeInternal(spec).test(sine);
+
+        // Assert
+        assertFalse(matches);
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -274,11 +274,10 @@
                   </execution>
               </executions>
           </plugin>
-
           <plugin>
               <groupId>org.apache.maven.plugins</groupId>
               <artifactId>maven-gpg-plugin</artifactId>
-              <version>1.6</version>
+              <version>3.0.1</version>
               <executions>
                   <execution>
                       <id>sign-artifacts</id>
@@ -286,13 +285,9 @@
                       <goals>
                           <goal>sign</goal>
                       </goals>
-                      <configuration>
-                          <passphraseServerId>${gpg.passphrase}</passphraseServerId>
-                      </configuration>
                   </execution>
               </executions>
           </plugin>
-
           <plugin>
               <groupId>org.sonatype.plugins</groupId>
               <artifactId>nexus-staging-maven-plugin</artifactId>


### PR DESCRIPTION
Introduces `UnorderedPointsFeature`, with the tag `has-points`, which matches if points appear regardless of order. Also introduces the `any` sector for points feature specs to match the specified point type regardless of sector.