### PR TITLE
Fix erroneous quadrant triggering when a line stops at the axis

### DIFF
--- a/library/src/main/java/org/isaacphysics/graphchecker/geometry/SectorBuilder.java
+++ b/library/src/main/java/org/isaacphysics/graphchecker/geometry/SectorBuilder.java
@@ -194,6 +194,20 @@ public class SectorBuilder {
     }
 
     /**
+     * Helper method to create a quadrant sector centred on the origin with axis slop
+     *
+     * @param axis1 The direction of one side of the quadrant
+     * @param axis2 The direction of the other side of the quadrant
+     * @return The segments of the quadrant
+     */
+    private List<Segment> sloppyQuadrant(Point axis1, Point axis2) {
+        final Point axis1Scaled = axis1.times(settings.getAxisSlop());
+        final Point axis2Scaled = axis2.times(settings.getAxisSlop());
+        final Point shiftedOrigin = axis1Scaled.add(axis2Scaled);
+        return quadrant(shiftedOrigin, axis1Scaled, axis2Scaled);
+    }
+
+    /**
      * Helper to create a Sector which represents an area near an axis.
      *
      * The area is defined as between the points left and right, scaled by AXIS_SLOP, extending out to infinity in the
@@ -269,10 +283,10 @@ public class SectorBuilder {
             .put(POSITIVE_Y_AXIS, builder -> builder.sloppyAxis(LEFT, RIGHT, UP))
             .put(NEGATIVE_Y_AXIS, builder -> builder.sloppyAxis(RIGHT, LEFT, DOWN))
 
-            .put(TOP_LEFT, builder -> builder.centeredQuadrant(LEFT, UP))
-            .put(TOP_RIGHT, builder -> builder.centeredQuadrant(RIGHT, UP))
-            .put(BOTTOM_LEFT, builder -> builder.centeredQuadrant(LEFT, DOWN))
-            .put(BOTTOM_RIGHT, builder -> builder.centeredQuadrant(RIGHT, DOWN))
+            .put(TOP_LEFT, builder -> builder.sloppyQuadrant(LEFT, UP))
+            .put(TOP_RIGHT, builder -> builder.sloppyQuadrant(RIGHT, UP))
+            .put(BOTTOM_LEFT, builder -> builder.sloppyQuadrant(LEFT, DOWN))
+            .put(BOTTOM_RIGHT, builder -> builder.sloppyQuadrant(RIGHT, DOWN))
 
             .put(LEFT_HALF, builder -> builder.centeredHalf(UP))
             .put(RIGHT_HALF, builder -> builder.centeredHalf(DOWN))

--- a/library/src/main/java/org/isaacphysics/graphchecker/geometry/Segment.java
+++ b/library/src/main/java/org/isaacphysics/graphchecker/geometry/Segment.java
@@ -130,10 +130,17 @@ public class Segment {
             return false;
         }
 
-         // Project originPoints onto line and check inside this segment
+        // Project originPoints onto line and check inside this segment
+        // equivalent to |b| x |b| x cos(0) = |b|^2
         double dotEndPrime = endPrime.getX() * endPrime.getX() + endPrime.getY() * endPrime.getY();
+        // equivalent to |a| x |b| x cos(theta)
         double pDotEndPrime = pPrime.getX() * endPrime.getX() + pPrime.getY() * endPrime.getY();
+        // equivalent to (|a| x cos(theta)) / |b| (that is a normalised sign of a)
         double coefficientOfSegment = pDotEndPrime / dotEndPrime;
+        // If openBothEnds then don't worry about it being "behind"
+        //      Otherwise must make sure it doesn't go "behind"
+        // Must also remain within the length of the segment
+        //      Unless this has a specific side
         return (this.openBothEnds || coefficientOfSegment >= 0) && (this.side != null || coefficientOfSegment <= 1);
     }
 

--- a/library/src/test/java/org/isaacphysics/graphchecker/features/FeaturesTest.java
+++ b/library/src/test/java/org/isaacphysics/graphchecker/features/FeaturesTest.java
@@ -67,9 +67,12 @@ public class FeaturesTest {
     public void testLineRecognitionWorks() {
         Predicate<Input> testFeature = new Features().matcher("line: 1; through:  bottomLeft\r\nline: 2; through: topRight");
 
+        double axisSlop = SettingsWrapper.DEFAULT.getAxisSlop();
+
+        // Because of axisSlop |minX| < 1/slop (so that Y > slop) and X > slop
         assertTrue(testFeature.test(inputOf(
-            lineOf(x -> 1 / x, -10, -0.01),
-            lineOf(x -> 1 / x, 0.01, 10)
+            lineOf(x -> 1 / x, -(1/axisSlop), -axisSlop),
+            lineOf(x -> 1 / x, axisSlop, 1/axisSlop)
         )));
 
         assertFalse(testFeature.test(inputOf(
@@ -117,9 +120,11 @@ public class FeaturesTest {
             "line: 2; slope: start = down",
             "line: 2; slope: end= flat"));
 
+        double axisSlop = SettingsWrapper.DEFAULT.getAxisSlop();
+
         assertTrue(testFeature.test(inputOf(
-            lineOf(x -> 1 / x, -10, -0.01),
-            lineOf(x -> 1 / x, 0.01, 10)
+            lineOf(x -> 1 / x, -(1/axisSlop), -axisSlop),
+            lineOf(x -> 1 / x, axisSlop, 1/axisSlop)
         )));
     }
 

--- a/library/src/test/java/org/isaacphysics/graphchecker/geometry/SectorTest.java
+++ b/library/src/test/java/org/isaacphysics/graphchecker/geometry/SectorTest.java
@@ -176,6 +176,10 @@ public class SectorTest {
 
     @Test
     public void quadrantsHaveCorrectPointHandling() {
+        // ARRANGE
+        double axisSlop = SettingsWrapper.DEFAULT.getAxisSlop();
+        Point sloppyOrigin = new Point(axisSlop, axisSlop);
+
         Sector[] quadrants = new Sector[] {
             sectorBuilder.byName(SectorBuilder.TOP_RIGHT),
             sectorBuilder.byName(SectorBuilder.TOP_LEFT),
@@ -186,17 +190,19 @@ public class SectorTest {
         Point[] outsidePoints = new Point[] {
                 x_1y_1,
                 x0y_1,
-                new Point(1, -0.0001),
+                new Point(1, -0.019),
+                new Point(1, 0.019), // Make sure the slop is ignored
         };
 
         Point[] insidePoints = new Point[] {
                 x1y1,
-                new Point(+0.005, 0.0001),
-                new Point(+0.005, 10),
-                new Point(100, 0.01),
-                x0y0,
+                new Point(+0.0205, 0.0201),
+                new Point(+0.0205, 10),
+                new Point(100, 0.0205),
+                sloppyOrigin,
         };
 
+        // ASSERT
         for (Sector quadrant : quadrants) {
             for (Point p : outsidePoints) {
                 assertFalse(quadrant + " should not contain " + p, quadrant.contains(p));


### PR DESCRIPTION
**Breaking change** certain lines will now be classified differently as it was previously assumed that the quadrants had no leeway.

axisSlop was only considered when crossing the axes and not in deciding whether a point was in a quadrant or not. This meant that single pixels across axes would trigger a quadrant when this is not really reasonable.

Requires https://github.com/isaacphysics/isaac-api/pull/565 to fully function as the slop is currently too tight.